### PR TITLE
Changed instructions to use forking

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,14 @@ You can [join GitHub](http://github.com/join) to get started.
 ## Teams
 We'll add teams during the event. Follow these steps to help us add you.
 1. Create a GitHub account if you don't have one.
-2. Clone this repo and edit this page by adding your name and team name to the file, and then commiting it locally.
+2. Fork this repo
 - [ ] Add screen shot here to show the process
-3. Submit a pull request on the repo. Now we have your Github details and know which team you belong to.
+3. Edit this page by adding your name and team name to the file
+4. Commit the changes as a new branch
 - [ ] Add screen shot here to show the process
-4. We'll then create the team repos for you to use.
+5. Submit a pull request on the repo. Now we have your Github details and know which team you belong to.
+- [ ] Add screen shot here to show the process
+6. We'll then create the team repos for you to use.
 
 ## Having problems?
 This process relies on several online services running. Here is the checklist of their status pages just to double check:


### PR DESCRIPTION
Changing the process to using a Fork rather than a clone means that it can all be done in the browser without the need to confuse people with installing command line or desktop Git at this stage.